### PR TITLE
docs: add JSDoc to all interface methods

### DIFF
--- a/src/interfaces/Collection.ts
+++ b/src/interfaces/Collection.ts
@@ -8,6 +8,13 @@ import type { Iterator } from "./Iterator";
  * Some are ordered and others unordered.
  *
  * @template E The type of elements in this collection
+ *
+ * @example
+ * const list = new ArrayList<number>();
+ * list.add(1); list.add(2);
+ * list.size();     // 2
+ * list.contains(1); // true
+ * list.toArray();  // [1, 2]
  */
 export interface Collection<E> {
   /**

--- a/src/interfaces/Deque.ts
+++ b/src/interfaces/Deque.ts
@@ -7,6 +7,13 @@ import type { Queue } from "./Queue";
  * This interface mirrors Java's Deque semantics while remaining TypeScript-friendly.
  *
  * @template E The type of elements in this deque
+ *
+ * @example
+ * const deque = new LinkedDeque<number>();
+ * deque.addFirst(1); deque.addLast(2);
+ * deque.peekFirst(); // 1
+ * deque.peekLast();  // 2
+ * deque.pollFirst(); // 1 (removed)
  */
 export interface Deque<E> extends Queue<E> {
   /**

--- a/src/interfaces/Iterator.ts
+++ b/src/interfaces/Iterator.ts
@@ -3,6 +3,12 @@
  * Follows the Iterator pattern similar to Java's Iterator.
  *
  * @template E The type of elements in the iteration
+ *
+ * @example
+ * const list = new ArrayList<number>();
+ * list.add(1); list.add(2);
+ * const it = list.iterator();
+ * while (it.hasNext()) console.log(it.next()); // 1, 2
  */
 export interface Iterator<E> {
   /**

--- a/src/interfaces/List.ts
+++ b/src/interfaces/List.ts
@@ -5,6 +5,13 @@ import type { Collection } from "./Collection";
  * Lists typically allow duplicate elements and access by index.
  *
  * @template E The type of elements in this list
+ *
+ * @example
+ * const list = new ArrayList<string>();
+ * list.add('a'); list.add('b'); list.add('c');
+ * list.get(0);      // 'a'
+ * list.indexOf('b'); // 1
+ * list.subList(0, 2).toArray(); // ['a', 'b']
  */
 export interface List<E> extends Collection<E> {
   /**

--- a/src/interfaces/Map.ts
+++ b/src/interfaces/Map.ts
@@ -7,6 +7,13 @@ import type { Iterator } from "./Iterator";
  *
  * @template K The type of keys maintained by this map
  * @template V The type of mapped values
+ *
+ * @example
+ * const map = new HashMap<string, number>();
+ * map.put('a', 1); map.put('b', 2);
+ * map.get('a');          // 1
+ * map.containsKey('b');  // true
+ * map.size();            // 2
  */
 export interface Map<K, V> {
   /**

--- a/src/interfaces/NavigableMap.ts
+++ b/src/interfaces/NavigableMap.ts
@@ -2,18 +2,101 @@ import type { SortedMap } from "./SortedMap";
 
 /**
  * A sorted map with navigation methods returning closest matches for search targets.
+ * Extends SortedMap with methods to find nearest keys relative to a given key.
  *
  * @template K key type
  * @template V value type
+ *
+ * @example
+ * const map = new TreeMap<number, string>();
+ * map.put(1, 'a'); map.put(3, 'c'); map.put(5, 'e');
+ * map.lowerKey(3);   // 1
+ * map.ceilingKey(4); // 5
  */
 export interface NavigableMap<K, V> extends SortedMap<K, V> {
+  /**
+   * Returns the greatest key strictly less than the given key, or undefined if no such key exists.
+   *
+   * @param key - The reference key
+   * @returns The greatest key strictly less than the given key, or undefined
+   * @example
+   * map.put(1, 'a'); map.put(3, 'c');
+   * map.lowerKey(3); // 1
+   */
   lowerKey(key: K): K | undefined;
+
+  /**
+   * Returns the greatest key less than or equal to the given key, or undefined if no such key exists.
+   *
+   * @param key - The reference key
+   * @returns The greatest key less than or equal to the given key, or undefined
+   * @example
+   * map.put(1, 'a'); map.put(3, 'c');
+   * map.floorKey(2); // 1
+   */
   floorKey(key: K): K | undefined;
+
+  /**
+   * Returns the least key greater than or equal to the given key, or undefined if no such key exists.
+   *
+   * @param key - The reference key
+   * @returns The least key greater than or equal to the given key, or undefined
+   * @example
+   * map.put(1, 'a'); map.put(3, 'c');
+   * map.ceilingKey(2); // 3
+   */
   ceilingKey(key: K): K | undefined;
+
+  /**
+   * Returns the least key strictly greater than the given key, or undefined if no such key exists.
+   *
+   * @param key - The reference key
+   * @returns The least key strictly greater than the given key, or undefined
+   * @example
+   * map.put(1, 'a'); map.put(3, 'c');
+   * map.higherKey(1); // 3
+   */
   higherKey(key: K): K | undefined;
 
+  /**
+   * Returns a key-value pair for the least key in this map.
+   *
+   * @returns A tuple [key, value] for the smallest key
+   * @throws Error if this map is empty
+   * @example
+   * map.put(2, 'b'); map.put(1, 'a');
+   * map.firstEntry(); // [1, 'a']
+   */
   firstEntry(): [K, V];
+
+  /**
+   * Returns a key-value pair for the greatest key in this map.
+   *
+   * @returns A tuple [key, value] for the largest key
+   * @throws Error if this map is empty
+   * @example
+   * map.put(1, 'a'); map.put(3, 'c');
+   * map.lastEntry(); // [3, 'c']
+   */
   lastEntry(): [K, V];
+
+  /**
+   * Removes and returns a key-value pair for the least key, or undefined if this map is empty.
+   *
+   * @returns A tuple [key, value] for the smallest key, or undefined if empty
+   * @example
+   * map.put(1, 'a'); map.put(2, 'b');
+   * map.pollFirstEntry(); // [1, 'a'] — map now has only key 2
+   */
   pollFirstEntry(): [K, V] | undefined;
+
+  /**
+   * Removes and returns a key-value pair for the greatest key, or undefined if this map is empty.
+   *
+   * @returns A tuple [key, value] for the largest key, or undefined if empty
+   * @example
+   * map.put(1, 'a'); map.put(2, 'b');
+   * map.pollLastEntry(); // [2, 'b'] — map now has only key 1
+   */
   pollLastEntry(): [K, V] | undefined;
 }

--- a/src/interfaces/NavigableSet.ts
+++ b/src/interfaces/NavigableSet.ts
@@ -3,17 +3,89 @@ import type { SortedSet } from "./SortedSet";
 
 /**
  * A sorted set with navigation methods returning closest matches for search targets.
+ * Extends SortedSet with methods to find nearest elements relative to a given value.
  *
  * @template E element type
+ *
+ * @example
+ * const set = new TreeSet<number>();
+ * set.add(1); set.add(3); set.add(5);
+ * set.lower(3);   // 1
+ * set.ceiling(4); // 5
  */
 export interface NavigableSet<E> extends SortedSet<E> {
+  /**
+   * Returns the greatest element strictly less than the given element, or undefined if no such element exists.
+   *
+   * @param element - The reference element
+   * @returns The greatest element strictly less than the given element, or undefined
+   * @example
+   * set.add(1); set.add(3);
+   * set.lower(3); // 1
+   */
   lower(element: E): E | undefined;
+
+  /**
+   * Returns the greatest element less than or equal to the given element, or undefined if no such element exists.
+   *
+   * @param element - The reference element
+   * @returns The greatest element less than or equal to the given element, or undefined
+   * @example
+   * set.add(1); set.add(3);
+   * set.floor(2); // 1
+   */
   floor(element: E): E | undefined;
+
+  /**
+   * Returns the least element greater than or equal to the given element, or undefined if no such element exists.
+   *
+   * @param element - The reference element
+   * @returns The least element greater than or equal to the given element, or undefined
+   * @example
+   * set.add(1); set.add(3);
+   * set.ceiling(2); // 3
+   */
   ceiling(element: E): E | undefined;
+
+  /**
+   * Returns the least element strictly greater than the given element, or undefined if no such element exists.
+   *
+   * @param element - The reference element
+   * @returns The least element strictly greater than the given element, or undefined
+   * @example
+   * set.add(1); set.add(3);
+   * set.higher(1); // 3
+   */
   higher(element: E): E | undefined;
 
+  /**
+   * Retrieves and removes the first (lowest) element, or returns undefined if this set is empty.
+   *
+   * @returns The first element, or undefined if this set is empty
+   * @example
+   * set.add(1); set.add(2);
+   * set.pollFirst(); // 1 — set now contains only 2
+   */
   pollFirst(): E | undefined;
+
+  /**
+   * Retrieves and removes the last (highest) element, or returns undefined if this set is empty.
+   *
+   * @returns The last element, or undefined if this set is empty
+   * @example
+   * set.add(1); set.add(2);
+   * set.pollLast(); // 2 — set now contains only 1
+   */
   pollLast(): E | undefined;
 
+  /**
+   * Returns an iterator over elements in this set in descending order.
+   *
+   * @returns An iterator traversing elements from highest to lowest
+   * @example
+   * set.add(1); set.add(2); set.add(3);
+   * const it = set.descendingIterator();
+   * it.next(); // 3
+   */
   descendingIterator(): Iterator<E>;
 }

--- a/src/interfaces/Queue.ts
+++ b/src/interfaces/Queue.ts
@@ -8,6 +8,13 @@ import type { Collection } from "./Collection";
  * but other orderings are possible (e.g., Priority Queue, Deque).
  *
  * @template E The type of elements in this queue
+ *
+ * @example
+ * const queue = new LinkedQueue<number>();
+ * queue.offer(1); queue.offer(2);
+ * queue.peek();   // 1 (not removed)
+ * queue.poll();   // 1 (removed)
+ * queue.size();   // 1
  */
 export interface Queue<E> extends Collection<E> {
   /**

--- a/src/interfaces/Set.ts
+++ b/src/interfaces/Set.ts
@@ -5,6 +5,12 @@ import type { Collection } from "./Collection";
  * This interface models the mathematical set abstraction.
  *
  * @template E The type of elements in this set
+ *
+ * @example
+ * const set = new HashSet<number>();
+ * set.add(1); set.add(2); set.add(1);
+ * set.size();      // 2 (no duplicates)
+ * set.contains(1); // true
  */
 export interface Set<E> extends Collection<E> {
   /**

--- a/src/interfaces/SortedMap.ts
+++ b/src/interfaces/SortedMap.ts
@@ -2,33 +2,76 @@ import type { Map as MapInterface } from "./Map";
 
 /**
  * A map that further provides a total ordering on its keys.
+ * Keys are ordered using their natural ordering or a comparator provided at creation time.
  *
  * @template K key type
  * @template V value type
+ *
+ * @example
+ * const map = new TreeMap<number, string>();
+ * map.put(3, 'c'); map.put(1, 'a'); map.put(2, 'b');
+ * map.firstKey(); // 1
+ * map.lastKey();  // 3
  */
 export interface SortedMap<K, V> extends MapInterface<K, V> {
   /**
    * Returns the first (lowest) key currently in this map.
+   *
+   * @returns The first key in this map
+   * @throws Error if this map is empty
+   * @example
+   * map.put(2, 'b'); map.put(1, 'a');
+   * map.firstKey(); // 1
    */
   firstKey(): K;
 
   /**
    * Returns the last (highest) key currently in this map.
+   *
+   * @returns The last key in this map
+   * @throws Error if this map is empty
+   * @example
+   * map.put(1, 'a'); map.put(3, 'c');
+   * map.lastKey(); // 3
    */
   lastKey(): K;
 
   /**
-   * Returns a view containing keys strictly less than (or equal if inclusive) toKey.
+   * Returns a view of the portion of this map whose keys are less than (or equal to, if inclusive) toKey.
+   *
+   * @param toKey - High endpoint of the keys in the returned map
+   * @param inclusive - Whether toKey is included in the returned map (default false)
+   * @returns A view of the portion of this map whose keys are less than toKey
+   * @example
+   * map.put(1, 'a'); map.put(2, 'b'); map.put(3, 'c');
+   * map.headMap(3).keys(); // [1, 2]
    */
   headMap(toKey: K, inclusive?: boolean): SortedMap<K, V>;
 
   /**
-   * Returns a view containing keys greater than (or equal if inclusive) fromKey.
+   * Returns a view of the portion of this map whose keys are greater than (or equal to, if inclusive) fromKey.
+   *
+   * @param fromKey - Low endpoint of the keys in the returned map
+   * @param inclusive - Whether fromKey is included in the returned map (default true)
+   * @returns A view of the portion of this map whose keys are greater than fromKey
+   * @example
+   * map.put(1, 'a'); map.put(2, 'b'); map.put(3, 'c');
+   * map.tailMap(2).keys(); // [2, 3]
    */
   tailMap(fromKey: K, inclusive?: boolean): SortedMap<K, V>;
 
   /**
-   * Returns a view containing keys in the given range.
+   * Returns a view of the portion of this map whose keys range from fromKey to toKey.
+   *
+   * @param fromKey - Low endpoint of the keys in the returned map
+   * @param toKey - High endpoint of the keys in the returned map
+   * @param fromInclusive - Whether fromKey is included (default true)
+   * @param toInclusive - Whether toKey is included (default false)
+   * @returns A view of the specified key range
+   * @throws Error if fromKey is greater than toKey
+   * @example
+   * map.put(1, 'a'); map.put(2, 'b'); map.put(3, 'c'); map.put(4, 'd');
+   * map.subMap(2, 4).keys(); // [2, 3]
    */
   subMap(
     fromKey: K,

--- a/src/interfaces/SortedSet.ts
+++ b/src/interfaces/SortedSet.ts
@@ -2,32 +2,75 @@ import type { Set as SetInterface } from "./Set";
 
 /**
  * A set that provides a total ordering on its elements.
+ * Elements are ordered using their natural ordering or a comparator provided at creation time.
  *
  * @template E element type
+ *
+ * @example
+ * const set = new TreeSet<number>();
+ * set.add(3); set.add(1); set.add(2);
+ * set.first(); // 1
+ * set.last();  // 3
  */
 export interface SortedSet<E> extends SetInterface<E> {
   /**
    * Returns the first (lowest) element currently in this set.
+   *
+   * @returns The first element in this set
+   * @throws Error if this set is empty
+   * @example
+   * set.add(3); set.add(1); set.add(2);
+   * set.first(); // 1
    */
   first(): E;
 
   /**
    * Returns the last (highest) element currently in this set.
+   *
+   * @returns The last element in this set
+   * @throws Error if this set is empty
+   * @example
+   * set.add(1); set.add(3);
+   * set.last(); // 3
    */
   last(): E;
 
   /**
-   * Returns a view containing elements strictly less than (or equal if inclusive) toElement.
+   * Returns a view of the portion of this set whose elements are less than (or equal to, if inclusive) toElement.
+   *
+   * @param toElement - High endpoint of the elements in the returned set
+   * @param inclusive - Whether toElement is included in the returned set (default false)
+   * @returns A view of the portion of this set whose elements are less than toElement
+   * @example
+   * set.add(1); set.add(2); set.add(3);
+   * set.headSet(3).toArray(); // [1, 2]
    */
   headSet(toElement: E, inclusive?: boolean): SortedSet<E>;
 
   /**
-   * Returns a view containing elements greater than (or equal if inclusive) fromElement.
+   * Returns a view of the portion of this set whose elements are greater than (or equal to, if inclusive) fromElement.
+   *
+   * @param fromElement - Low endpoint of the elements in the returned set
+   * @param inclusive - Whether fromElement is included in the returned set (default true)
+   * @returns A view of the portion of this set whose elements are greater than fromElement
+   * @example
+   * set.add(1); set.add(2); set.add(3);
+   * set.tailSet(2).toArray(); // [2, 3]
    */
   tailSet(fromElement: E, inclusive?: boolean): SortedSet<E>;
 
   /**
-   * Returns a view containing elements in the given range.
+   * Returns a view of the portion of this set whose elements range from fromElement to toElement.
+   *
+   * @param fromElement - Low endpoint of the elements in the returned set
+   * @param toElement - High endpoint of the elements in the returned set
+   * @param fromInclusive - Whether fromElement is included (default true)
+   * @param toInclusive - Whether toElement is included (default false)
+   * @returns A view of the specified element range
+   * @throws Error if fromElement is greater than toElement
+   * @example
+   * set.add(1); set.add(2); set.add(3); set.add(4);
+   * set.subSet(2, 4).toArray(); // [2, 3]
    */
   subSet(
     fromElement: E,

--- a/src/interfaces/Stack.ts
+++ b/src/interfaces/Stack.ts
@@ -5,6 +5,13 @@ import type { Collection } from "./Collection";
  * Provides push and pop operations for stack behavior.
  *
  * @template E The type of elements in this stack
+ *
+ * @example
+ * const stack = new LinkedStack<number>();
+ * stack.push(1); stack.push(2);
+ * stack.peek(); // 2 (not removed)
+ * stack.pop();  // 2 (removed)
+ * stack.size(); // 1
  */
 export interface Stack<E> extends Collection<E> {
   /**


### PR DESCRIPTION
## Description

Add full JSDoc documentation to all interface methods across the 11 interface files in `src/interfaces/`. This improves developer experience, enables IDE IntelliSense, and brings the interfaces up to the same documentation standard as the implementation classes.

Fixes #52

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Other (please specify):

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code for security vulnerabilities
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

N/A — documentation-only change.

## How Has This Been Tested?

This is a documentation-only change (JSDoc comments). No runtime behaviour is modified.

- [x] Ran `pnpm lint` — no new warnings
- [x] Ran `pnpm build` — compiles without errors
- [x] Verified JSDoc renders correctly in IDE IntelliSense

**Test Configuration**:
- OS: Windows 11
- Node.js version: 18+
- Other dependencies: pnpm, TypeScript 5.9

## Related Documentation

- Issue: https://github.com/Karelaking/ts-collections/issues/52
- Style reference: `src/list/ArrayList.ts` (existing JSDoc pattern)

## Additional Notes

**What was added:**
- `NavigableMap.ts` — full JSDoc added to all 8 methods (previously had none)
- `NavigableSet.ts` — full JSDoc added to all 7 methods (previously had none)
- `SortedMap.ts` — added `@param`, `@returns`, `@throws`, and `@example` to headMap, tailMap, subMap
- `SortedSet.ts` — added `@param`, `@returns`, `@throws`, and `@example` to headSet, tailSet, subSet
- `Collection.ts`, `List.ts`, `Map.ts`, `Set.ts`, `Queue.ts`, `Stack.ts`, `Iterator.ts`, `Deque.ts` — added interface-level `@example` blocks

Each method follows the JSDoc style from CONTRIBUTING.md: `@param`, `@returns`, `@throws` (where applicable), and a runnable `@example`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `pollLastEntry()` method to NavigableMap for removing the entry with the greatest key.

* **Documentation**
  * Enhanced interface documentation across Collection, Deque, Iterator, List, Map, NavigableMap, NavigableSet, Queue, Set, SortedMap, SortedSet, and Stack with comprehensive usage examples and detailed method descriptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Karelaking/ts-collections/pull/61)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->