### PR TITLE
[ENHANCEMENT] Error messages lack operational context in validation failures

### DIFF
--- a/src/abstracts/AbstractCollection.ts
+++ b/src/abstracts/AbstractCollection.ts
@@ -1,5 +1,11 @@
 import type { Iterator, Collection } from "../interfaces";
-import { z, type ZodSchema } from "zod";
+import { type ZodSchema } from "zod";
+import {
+  createCollectionValidationError,
+  describeValidationValue,
+  toValidationError,
+  type ValidationContext,
+} from "../utils/validation";
 
 /**
  * Options for runtime type validation in collections.
@@ -109,6 +115,21 @@ export abstract class AbstractCollection<E> implements Collection<E> {
   protected schema?: ZodSchema<E>;
   protected strict: boolean = true; // ✓ DEFAULT: Type safety is ON (like Java)
   protected inferredType?: string;
+
+  protected createValidationContext(
+    operation: string,
+    targetDescription: string,
+    targetValue: unknown,
+    sizeBefore?: number,
+  ): ValidationContext {
+    return {
+      collectionType: this.constructor.name,
+      operation,
+      targetDescription,
+      targetValue,
+      ...(sizeBefore === undefined ? {} : { sizeBefore }),
+    };
+  }
 
   /**
    * Initializes the collection with optional type validation settings.
@@ -287,25 +308,29 @@ export abstract class AbstractCollection<E> implements Collection<E> {
    * @param element The element to validate
    * @throws {TypeError} If type validation fails
    */
-  protected validateElementType(element: unknown): void {
+  protected validateElementType(
+    element: unknown,
+    context?: ValidationContext,
+  ): void {
     // Only validate if strict mode is enabled
     if (!this.strict) {
       return;
     }
+
+    const validationContext =
+      context ??
+      this.createValidationContext("validate", "element", element, this.size());
 
     // Zod schema takes highest precedence (for power users)
     if (this.schema) {
       try {
         this.schema.parse(element);
       } catch (error) {
-        if (error instanceof z.ZodError) {
-          const issues = error.issues
-            .map(issue => {
-              const path = issue.path.length > 0 ? `${issue.path.join('.')}` : 'root';
-              return `${path}: ${issue.message}`;
-            })
-            .join('; ');
-          throw new TypeError(`Validation failed: ${issues}`);
+        if (error instanceof Error) {
+          throw createCollectionValidationError(
+            toValidationError(error),
+            validationContext,
+          );
         }
         throw error;
       }
@@ -316,7 +341,7 @@ export abstract class AbstractCollection<E> implements Collection<E> {
     if (this.typeValidator) {
       if (!this.typeValidator(element)) {
         throw new TypeError(
-          'Type validation failed: element does not match the expected type'
+          `${validationContext.collectionType}.${validationContext.operation}() validation failed: Expected value matching custom validator for ${validationContext.targetDescription}, but got ${describeValidationValue(element)}`
         );
       }
       return;
@@ -333,7 +358,7 @@ export abstract class AbstractCollection<E> implements Collection<E> {
       const elementType = this.getTypeString(element);
       if (elementType !== this.inferredType) {
         throw new TypeError(
-          `Type mismatch: expected ${this.inferredType}, but got ${elementType}`
+          `${validationContext.collectionType}.${validationContext.operation}() validation failed: Expected ${this.inferredType} for ${validationContext.targetDescription}, but got ${describeValidationValue(element)}`
         );
       }
     }

--- a/src/abstracts/AbstractMap.ts
+++ b/src/abstracts/AbstractMap.ts
@@ -1,5 +1,11 @@
-import { type ZodSchema, z } from "zod";
+import { type ZodSchema } from "zod";
 import type { Collection, Iterator, Map as MapInterface } from "../interfaces";
+import {
+  createCollectionValidationError,
+  describeValidationValue,
+  toValidationError,
+  type ValidationContext,
+} from "../utils/validation";
 
 /**
  * Options for runtime type validation in maps.
@@ -106,6 +112,21 @@ export abstract class AbstractMap<K, V> implements MapInterface<K, V> {
   protected strict: boolean = true; // ✓ DEFAULT: Type safety is ON (like Java)
   protected inferredKeyType?: string;
   protected inferredValueType?: string;
+
+  protected createValidationContext(
+    operation: string,
+    targetDescription: string,
+    targetValue: unknown,
+    sizeBefore?: number,
+  ): ValidationContext {
+    return {
+      collectionType: this.constructor.name,
+      operation,
+      targetDescription,
+      targetValue,
+      ...(sizeBefore === undefined ? {} : { sizeBefore }),
+    };
+  }
 
   /**
    * Initializes the map with optional type validation settings.
@@ -386,26 +407,25 @@ export abstract class AbstractMap<K, V> implements MapInterface<K, V> {
    * @param key The key to validate
    * @throws {TypeError} If key validation fails
    */
-  protected validateKeyType(key: unknown): void {
+  protected validateKeyType(key: unknown, context?: ValidationContext): void {
     // Only validate if strict mode is enabled
     if (!this.strict) {
       return;
     }
+
+    const validationContext =
+      context ?? this.createValidationContext("validate", "key", key, this.size());
 
     // Zod schema takes highest precedence (for power users)
     if (this.keySchema) {
       try {
         this.keySchema.parse(key);
       } catch (error) {
-        if (error instanceof z.ZodError) {
-          const issues = error.issues
-            .map((issue) => {
-              const path =
-                issue.path.length > 0 ? `${issue.path.join(".")}` : "root";
-              return `${path}: ${issue.message}`;
-            })
-            .join("; ");
-          throw new TypeError(`Key validation failed: ${issues}`);
+        if (error instanceof Error) {
+          throw createCollectionValidationError(
+            toValidationError(error),
+            validationContext,
+          );
         }
         throw error;
       }
@@ -416,7 +436,7 @@ export abstract class AbstractMap<K, V> implements MapInterface<K, V> {
     if (this.keyValidator) {
       if (!this.keyValidator(key)) {
         throw new TypeError(
-          "Key validation failed: key does not match the expected type",
+          `${validationContext.collectionType}.${validationContext.operation}() validation failed: Expected value matching custom validator for ${validationContext.targetDescription}, but got ${describeValidationValue(key)}`,
         );
       }
       return;
@@ -429,7 +449,7 @@ export abstract class AbstractMap<K, V> implements MapInterface<K, V> {
       const keyType = this.getTypeString(key);
       if (keyType !== this.inferredKeyType) {
         throw new TypeError(
-          `Key type mismatch: expected ${this.inferredKeyType}, but got ${keyType}`,
+          `${validationContext.collectionType}.${validationContext.operation}() validation failed: Expected ${this.inferredKeyType} for ${validationContext.targetDescription}, but got ${describeValidationValue(key)}`,
         );
       }
     }
@@ -447,26 +467,25 @@ export abstract class AbstractMap<K, V> implements MapInterface<K, V> {
    * @param value The value to validate
    * @throws {TypeError} If value validation fails
    */
-  protected validateValueType(value: unknown): void {
+  protected validateValueType(value: unknown, context?: ValidationContext): void {
     // Only validate if strict mode is enabled
     if (!this.strict) {
       return;
     }
+
+    const validationContext =
+      context ?? this.createValidationContext("validate", "value", value, this.size());
 
     // Zod schema takes highest precedence (for power users)
     if (this.valueSchema) {
       try {
         this.valueSchema.parse(value);
       } catch (error) {
-        if (error instanceof z.ZodError) {
-          const issues = error.issues
-            .map((issue) => {
-              const path =
-                issue.path.length > 0 ? `${issue.path.join(".")}` : "root";
-              return `${path}: ${issue.message}`;
-            })
-            .join("; ");
-          throw new TypeError(`Value validation failed: ${issues}`);
+        if (error instanceof Error) {
+          throw createCollectionValidationError(
+            toValidationError(error),
+            validationContext,
+          );
         }
         throw error;
       }
@@ -477,7 +496,7 @@ export abstract class AbstractMap<K, V> implements MapInterface<K, V> {
     if (this.valueValidator) {
       if (!this.valueValidator(value)) {
         throw new TypeError(
-          "Value validation failed: value does not match the expected type",
+          `${validationContext.collectionType}.${validationContext.operation}() validation failed: Expected value matching custom validator for ${validationContext.targetDescription}, but got ${describeValidationValue(value)}`,
         );
       }
       return;
@@ -490,7 +509,7 @@ export abstract class AbstractMap<K, V> implements MapInterface<K, V> {
       const valueType = this.getTypeString(value);
       if (valueType !== this.inferredValueType) {
         throw new TypeError(
-          `Value type mismatch: expected ${this.inferredValueType}, but got ${valueType}`,
+          `${validationContext.collectionType}.${validationContext.operation}() validation failed: Expected ${this.inferredValueType} for ${validationContext.targetDescription}, but got ${describeValidationValue(value)}`,
         );
       }
     }

--- a/src/list/ArrayList.ts
+++ b/src/list/ArrayList.ts
@@ -61,6 +61,15 @@ export class ArrayList<T> extends AbstractList<T> implements List<T> {
    * @returns true if the element was added successfully
    */
   override add(element: T): boolean {
+    this.validateElementType(
+      element,
+      this.createValidationContext(
+        "add",
+        `element at index ${this.elements.length}`,
+        element,
+        this.elements.length,
+      ),
+    );
     this.elements.push(element);
     return true;
   }
@@ -85,6 +94,15 @@ export class ArrayList<T> extends AbstractList<T> implements List<T> {
    */
   override set(index: number, element: T): T {
     this.checkIndex(index);
+    this.validateElementType(
+      element,
+      this.createValidationContext(
+        "set",
+        `element at index ${index}`,
+        element,
+        this.elements.length,
+      ),
+    );
     const oldElement = this.elements[index];
     this.elements[index] = element;
     return oldElement as T;
@@ -101,6 +119,15 @@ export class ArrayList<T> extends AbstractList<T> implements List<T> {
     if (index < 0 || index > this.elements.length) {
       throw new Error(`Index out of bounds: ${index}`);
     }
+    this.validateElementType(
+      element,
+      this.createValidationContext(
+        "addAt",
+        `element at index ${index}`,
+        element,
+        this.elements.length,
+      ),
+    );
     this.elements.splice(index, 0, element);
   }
 

--- a/src/list/LinkedList.ts
+++ b/src/list/LinkedList.ts
@@ -60,7 +60,15 @@ export class LinkedList<T> extends AbstractList<T> implements List<T> {
    * @returns true if added.
    */
   override add(element: T): boolean {
-    this.validateElementType(element);
+    this.validateElementType(
+      element,
+      this.createValidationContext(
+        "add",
+        `element at index ${this.elementCount}`,
+        element,
+        this.elementCount,
+      ),
+    );
     this.addLast(element);
     return true;
   }
@@ -70,7 +78,15 @@ export class LinkedList<T> extends AbstractList<T> implements List<T> {
    * @param element Element to add.
    */
   override addFirst(element: T): void {
-    this.validateElementType(element);
+    this.validateElementType(
+      element,
+      this.createValidationContext(
+        "addFirst",
+        "element at the front of the list",
+        element,
+        this.elementCount,
+      ),
+    );
     const newNode: Node<T> = {
       value: element,
       previous: null,
@@ -94,7 +110,15 @@ export class LinkedList<T> extends AbstractList<T> implements List<T> {
    * @param element Element to add.
    */
   override addLast(element: T): void {
-    this.validateElementType(element);
+    this.validateElementType(
+      element,
+      this.createValidationContext(
+        "addLast",
+        "element at the end of the list",
+        element,
+        this.elementCount,
+      ),
+    );
     const newNode: Node<T> = {
       value: element,
       previous: this.tail,
@@ -219,7 +243,15 @@ export class LinkedList<T> extends AbstractList<T> implements List<T> {
    */
   override set(index: number, element: T): T {
     this.checkIndex(index);
-    this.validateElementType(element);
+    this.validateElementType(
+      element,
+      this.createValidationContext(
+        "set",
+        `element at index ${index}`,
+        element,
+        this.elementCount,
+      ),
+    );
     const node = this.getNode(index);
     if (node === null) {
       throw new Error(`Element at index ${index} is undefined`);
@@ -240,7 +272,15 @@ export class LinkedList<T> extends AbstractList<T> implements List<T> {
       throw new Error(`Index out of bounds: ${index}`);
     }
 
-    this.validateElementType(element);
+    this.validateElementType(
+      element,
+      this.createValidationContext(
+        "addAt",
+        `element at index ${index}`,
+        element,
+        this.elementCount,
+      ),
+    );
 
     if (index === this.elementCount) {
       // Insert at end

--- a/src/map/HashMap.ts
+++ b/src/map/HashMap.ts
@@ -5,6 +5,7 @@ import {
 import type { Collection } from "../interfaces/Collection";
 import type { Iterator } from "../interfaces/Iterator";
 import type { Map as MapInterface } from "../interfaces/Map";
+import { formatValidationContextValue } from "../utils/validation";
 
 /**
  * A hash-based Map implementation using native JavaScript Map.
@@ -49,8 +50,24 @@ export class HashMap<K, V>
    * @returns The previous value associated with the key, or undefined if there was no mapping
    */
   override put(key: K, value: V): V | undefined {
-    this.validateKeyType(key);
-    this.validateValueType(value);
+    this.validateKeyType(
+      key,
+      this.createValidationContext(
+        "put",
+        `key ${formatValidationContextValue(key)}`,
+        key,
+        this.size(),
+      ),
+    );
+    this.validateValueType(
+      value,
+      this.createValidationContext(
+        "put",
+        `value for key ${formatValidationContextValue(key)}`,
+        value,
+        this.size(),
+      ),
+    );
     const oldValue = this.mapEntries.get(key);
     this.mapEntries.set(key, value);
     return oldValue;

--- a/src/map/TreeMap.ts
+++ b/src/map/TreeMap.ts
@@ -5,6 +5,7 @@ import {
 import type { Collection } from "../interfaces/Collection";
 import type { Iterator } from "../interfaces/Iterator";
 import type { NavigableMap } from "../interfaces/NavigableMap";
+import { formatValidationContextValue } from "../utils/validation";
 
 export interface TreeMapOptions<K, V> extends MapTypeValidationOptions<K, V> {
   comparator?: (a: K, b: K) => number;
@@ -57,8 +58,24 @@ export class TreeMap<K, V>
   }
 
   override put(key: K, value: V): V | undefined {
-    this.validateKeyType(key);
-    this.validateValueType(value);
+    this.validateKeyType(
+      key,
+      this.createValidationContext(
+        "put",
+        `key ${formatValidationContextValue(key)}`,
+        key,
+        this.size(),
+      ),
+    );
+    this.validateValueType(
+      value,
+      this.createValidationContext(
+        "put",
+        `value for key ${formatValidationContextValue(key)}`,
+        value,
+        this.size(),
+      ),
+    );
 
     const index = this.findKeyIndex(key);
     if (index >= 0) {

--- a/src/queue/LinkedDeque.ts
+++ b/src/queue/LinkedDeque.ts
@@ -24,12 +24,28 @@ export class LinkedDeque<T> extends AbstractDeque<T> implements Deque<T> {
   }
 
   override addFirst(element: T): void {
-    this.validateElementType(element);
+    this.validateElementType(
+      element,
+      this.createValidationContext(
+        "addFirst",
+        "deque element at the front",
+        element,
+        this.size(),
+      ),
+    );
     this.list.addFirst(element);
   }
 
   override addLast(element: T): void {
-    this.validateElementType(element);
+    this.validateElementType(
+      element,
+      this.createValidationContext(
+        "addLast",
+        "deque element at the back",
+        element,
+        this.size(),
+      ),
+    );
     this.list.addLast(element);
   }
 

--- a/src/queue/LinkedQueue.ts
+++ b/src/queue/LinkedQueue.ts
@@ -41,7 +41,15 @@ export class LinkedQueue<T> extends AbstractQueue<T> implements Queue<T> {
    * @returns true if the element was added to this queue, else false
    */
   override offer(element: T): boolean {
-    this.validateElementType(element);
+    this.validateElementType(
+      element,
+      this.createValidationContext(
+        "offer",
+        "queue element",
+        element,
+        this.elementCount,
+      ),
+    );
     const newNode: Node<T> = { value: element, next: null };
 
     if (this.tail === null) {

--- a/src/queue/PriorityQueue.ts
+++ b/src/queue/PriorityQueue.ts
@@ -27,7 +27,15 @@ export class PriorityQueue<T> extends AbstractQueue<T> implements Queue<T> {
   }
 
   override offer(element: T): boolean {
-    this.validateElementType(element);
+    this.validateElementType(
+      element,
+      this.createValidationContext(
+        "offer",
+        "priority queue element",
+        element,
+        this.heap.length,
+      ),
+    );
     this.heap.push(element);
     this.siftUp(this.heap.length - 1);
     return true;

--- a/src/set/HashSet.ts
+++ b/src/set/HashSet.ts
@@ -41,7 +41,15 @@ export class HashSet<T> extends AbstractSet<T> implements Set<T> {
    * @returns true if this set did not already contain the specified element
    */
   override add(element: T): boolean {
-    this.validateElementType(element);
+    this.validateElementType(
+      element,
+      this.createValidationContext(
+        "add",
+        "set element",
+        element,
+        this.elements.size,
+      ),
+    );
     const sizeBefore = this.elements.size;
     this.elements.add(element);
     return this.elements.size > sizeBefore;

--- a/src/set/TreeSet.ts
+++ b/src/set/TreeSet.ts
@@ -27,7 +27,15 @@ export class TreeSet<T> extends AbstractSet<T> implements NavigableSet<T> {
   }
 
   override add(element: T): boolean {
-    this.validateElementType(element);
+    this.validateElementType(
+      element,
+      this.createValidationContext(
+        "add",
+        "set element",
+        element,
+        this.orderedValues.length,
+      ),
+    );
 
     const index = this.findIndex(element);
     if (index >= 0) {

--- a/src/stack/LinkedStack.ts
+++ b/src/stack/LinkedStack.ts
@@ -23,7 +23,15 @@ export class LinkedStack<T> extends AbstractStack<T> implements Stack<T> {
    * @returns true if the element was pushed
    */
   override push(element: T): boolean {
-    this.validateElementType(element);
+    this.validateElementType(
+      element,
+      this.createValidationContext(
+        "push",
+        "stack element",
+        element,
+        this.list.size(),
+      ),
+    );
     this.list.addFirst(element);
     return true;
   }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,15 +1,26 @@
-import { z, type ZodSchema, ZodError } from 'zod';
+import { z, ZodError, type ZodSchema } from "zod";
 
 /**
- * Result type for validation operations
- * Represents either a successful validation or a validation error
+ * Result type for validation operations.
+ * Represents either a successful validation or a validation error.
  */
 export type ValidationResult<T> =
   | { success: true; data: T }
   | { success: false; error: ValidationError };
 
 /**
- * Structured validation error with detailed information
+ * Context for a collection validation failure.
+ */
+export interface ValidationContext {
+  collectionType: string;
+  operation: string;
+  targetDescription: string;
+  targetValue: unknown;
+  sizeBefore?: number;
+}
+
+/**
+ * Structured validation error with detailed information.
  */
 export interface ValidationError {
   message: string;
@@ -18,93 +29,228 @@ export interface ValidationError {
 }
 
 /**
- * Individual validation issue
+ * Individual validation issue.
  */
 export interface ValidationIssue {
   path: string;
   message: string;
   code: string;
+  expected?: string;
+  received?: string;
+}
+
+function describeType(value: unknown): string {
+  if (value === null) {
+    return "null";
+  }
+  if (value === undefined) {
+    return "undefined";
+  }
+  if (Array.isArray(value)) {
+    return "array";
+  }
+  return typeof value;
+}
+
+function describeValue(value: unknown): string {
+  if (typeof value === "string") {
+    return `"${value}"`;
+  }
+  if (typeof value === "bigint") {
+    return `${value}n`;
+  }
+  if (typeof value === "symbol") {
+    return value.toString();
+  }
+  if (
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    value === null ||
+    value === undefined
+  ) {
+    return String(value);
+  }
+
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
 }
 
 /**
- * Safe validation that returns a result instead of throwing
+ * Formats a value for use in contextual failure text.
+ *
+ * @param value The value to format
+ * @returns A readable representation without the runtime type prefix
+ */
+export function formatValidationContextValue(value: unknown): string {
+  return describeValue(value);
+}
+
+function describeValueWithType(value: unknown): string {
+  const type = describeType(value);
+  const renderedValue = describeValue(value);
+
+  if (renderedValue === type) {
+    return type;
+  }
+
+  return `${type} ${renderedValue}`;
+}
+
+/**
+ * Describes a value using its runtime type and a readable representation.
+ *
+ * @param value The value to describe
+ * @returns A type-aware description of the value
+ */
+export function describeValidationValue(value: unknown): string {
+  return describeValueWithType(value);
+}
+
+function mapIssueDetails(issue: ZodError["issues"][number]): ValidationIssue {
+  return {
+    path: issue.path.join("."),
+    message: issue.message,
+    code: issue.code,
+    ...("expected" in issue ? { expected: String(issue.expected) } : {}),
+    ...("received" in issue ? { received: String(issue.received) } : {}),
+  };
+}
+
+/**
+ * Converts a thrown error into a structured validation error.
+ *
+ * @param error The thrown error to normalize
+ * @returns A structured validation error representation
+ */
+export function toValidationError(error: unknown): ValidationError {
+  if (error instanceof ZodError) {
+    return {
+      message: error.message,
+      issues: error.issues.map(mapIssueDetails),
+      rawError: error,
+    };
+  }
+
+  return {
+    message: "Unknown validation error",
+    issues: [],
+    rawError: error instanceof Error ? error : new Error(String(error)),
+  };
+}
+
+function buildValidationHeader(context?: ValidationContext): string {
+  if (!context) {
+    return "Validation failed";
+  }
+
+  const sizeSuffix =
+    context.sizeBefore === undefined
+      ? ""
+      : ` (size before operation: ${context.sizeBefore})`;
+
+  return `${context.collectionType}.${context.operation}() validation failed${sizeSuffix}`;
+}
+
+function buildIssueMessage(
+  issue: ValidationIssue,
+  context?: ValidationContext,
+): string {
+  if (!context) {
+    if (issue.path) {
+      return `${issue.path}: ${issue.message}`;
+    }
+    return issue.message;
+  }
+
+  if (issue.code === "invalid_type" && issue.expected) {
+    return `Expected ${issue.expected} for ${context.targetDescription}, but got ${describeValueWithType(context.targetValue)}`;
+  }
+
+  if (issue.path) {
+    return `${context.targetDescription} (${issue.path}): ${issue.message}`;
+  }
+
+  return `${context.targetDescription}: ${issue.message}`;
+}
+
+/**
+ * Format validation error as a readable message.
+ *
+ * @param error The validation error to format
+ * @param context Optional collection context
+ * @returns Formatted error message
+ */
+export function formatValidationError(
+  error: ValidationError,
+  context?: ValidationContext,
+): string {
+  if (error.issues.length === 0) {
+    return context ? buildValidationHeader(context) : error.message;
+  }
+
+  const issueMessages = error.issues.map((issue) => buildIssueMessage(issue, context)).join("; ");
+
+  return `${buildValidationHeader(context)}: ${issueMessages}`;
+}
+
+/**
+ * Creates a TypeError with contextual collection validation details.
+ *
+ * @param error The structured validation error to format
+ * @param context Additional collection context to include in the message
+ * @returns A TypeError that preserves the original raw error as the cause
+ */
+export function createCollectionValidationError(
+  error: ValidationError,
+  context?: ValidationContext,
+): TypeError {
+  return new TypeError(formatValidationError(error, context), {
+    cause: error.rawError,
+  });
+}
+
+/**
+ * Safe validation that returns a result instead of throwing.
+ *
  * @param schema The Zod schema to validate against
  * @param data The data to validate
  * @returns A ValidationResult containing either the validated data or an error
  */
 export function validateSafe<T>(
   schema: ZodSchema<T>,
-  data: unknown
+  data: unknown,
 ): ValidationResult<T> {
   try {
     const validated = schema.parse(data);
     return { success: true, data: validated };
   } catch (error) {
-    if (error instanceof ZodError) {
-      return {
-        success: false,
-        error: {
-          message: error.message,
-          issues: error.issues.map(issue => ({
-            path: issue.path.join('.'),
-            message: issue.message,
-            code: issue.code,
-          })),
-          rawError: error,
-        },
-      };
-    }
     return {
       success: false,
-      error: {
-        message: 'Unknown validation error',
-        issues: [],
-        rawError: error instanceof Error ? error : new Error(String(error)),
-      },
+      error: toValidationError(error),
     };
   }
 }
 
 /**
- * Format validation error as a readable message
- * @param error The validation error to format
- * @returns Formatted error message
- */
-export function formatValidationError(error: ValidationError): string {
-  if (error.issues.length === 0) {
-    return error.message;
-  }
-
-  const issueMessages = error.issues
-    .map(issue => {
-      const path = issue.path ? `${issue.path}: ` : '';
-      return `${path}${issue.message}`;
-    })
-    .join('; ');
-
-  return `Validation failed: ${issueMessages}`;
-}
-
-/**
- * Create a type-safe validator function from a Zod schema
+ * Create a type-safe validator function from a Zod schema.
+ *
  * @param schema The Zod schema
+ * @param context Optional collection context for error messages
  * @returns A validator function that throws on invalid data
  */
-export function createValidator<T>(schema: ZodSchema<T>): (value: unknown) => T {
+export function createValidator<T>(
+  schema: ZodSchema<T>,
+  context?: ValidationContext,
+): (value: unknown) => T {
   return (value: unknown): T => {
     try {
       return schema.parse(value);
     } catch (error) {
       if (error instanceof ZodError) {
-        throw new TypeError(formatValidationError({
-          message: error.message,
-          issues: error.issues.map(issue => ({
-            path: issue.path.join('.'),
-            message: issue.message,
-            code: issue.code,
-          })),
-          rawError: error,
-        }));
+        throw createCollectionValidationError(toValidationError(error), context);
       }
       throw error;
     }
@@ -112,46 +258,56 @@ export function createValidator<T>(schema: ZodSchema<T>): (value: unknown) => T 
 }
 
 /**
- * Create a type-safe validator for a collection element with union type support
+ * Create a type-safe validator for a collection element with union type support.
  * Validates that a value matches one of the provided schemas (e.g., for multi-type collections)
+ *
  * @param schemas Array of Zod schemas (union type validation)
  * @returns A validator function that validates against any of the schemas
  */
 export function createUnionValidator<T>(
-  schemas: ZodSchema<T>[]
+  schemas: ZodSchema<T>[],
+  context?: ValidationContext,
 ): (value: unknown) => T {
   const unionSchema = z.union(schemas as [ZodSchema<T>, ...ZodSchema<T>[]]);
-  return createValidator(unionSchema);
+  return createValidator(unionSchema, context);
 }
 
 /**
- * Get type information from a Zod schema for debugging
+ * Get type information from a Zod schema for debugging.
+ *
  * @param schema The Zod schema
  * @returns A string description of the schema
  */
 export function getSchemaDescription(schema: ZodSchema<unknown>): string {
-  const schemaWithDef = schema as ZodSchema<unknown> & { _def?: { typeName?: string } };
+  const schemaWithDef = schema as ZodSchema<unknown> & {
+    _def?: { typeName?: string };
+  };
   if (schema instanceof z.ZodObject) {
-    const schemaObject = schema as ZodSchema<unknown> & { _shape?: Record<string, unknown> };
+    const schemaObject = schema as ZodSchema<unknown> & {
+      _shape?: Record<string, unknown>;
+    };
     const shape = schemaObject._shape;
-    if (!shape) return 'object { }';
+    if (!shape) return "object { }";
 
     const fields = Object.entries(shape)
       .map(([key, value]) => {
-        const fieldSchema = value as ZodSchema<unknown> & { _def?: { typeName?: string } };
-        return `${key}: ${fieldSchema._def?.typeName || 'unknown'}`;
+        const fieldSchema = value as ZodSchema<unknown> & {
+          _def?: { typeName?: string };
+        };
+        return `${key}: ${fieldSchema._def?.typeName || "unknown"}`;
       })
-      .join(', ');
+      .join(", ");
     return `object { ${fields} }`;
   }
 
   const def = schemaWithDef._def;
-  return def?.typeName || 'unknown';
+  return def?.typeName || "unknown";
 }
 
 /**
- * Extract inferred TypeScript type from a Zod schema
- * This is a type-level helper that should be used at compile time
+ * Extract inferred TypeScript type from a Zod schema.
+ * This is a type-level helper that should be used at compile time.
+ *
  * @example
  * const userSchema = z.object({ name: z.string(), age: z.number() });
  * type User = z.infer<typeof userSchema>;
@@ -160,15 +316,16 @@ export function getSchemaDescription(schema: ZodSchema<unknown>): string {
 export type SchemaType<T extends ZodSchema<any>> = z.infer<T>;
 
 /**
- * Create a composite validator for validating collections with transformation
- * Useful for collections that need to transform or validate elements before storage
+ * Create a composite validator for validating collections with transformation.
+ * Useful for collections that need to transform or validate elements before storage.
+ *
  * @param schema The Zod schema for individual elements
  * @param transform Optional transformation function
  * @returns A validator that validates and optionally transforms
  */
 export function createTransformingValidator<T, U>(
   schema: ZodSchema<T>,
-  transform?: (value: T) => U
+  transform?: (value: T) => U,
 ): (value: unknown) => U {
   return (value: unknown): U => {
     const validated = schema.parse(value) as T;

--- a/test/list/ArrayList.test.ts
+++ b/test/list/ArrayList.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import { z } from "zod";
 import { ArrayList } from "../../src/list/ArrayList";
 import { describeList } from "../interfaces/List";
 
@@ -71,6 +72,34 @@ describe("ArrayList - Core Methods", () => {
       expect(list.add(1)).toBe(true);
       expect(list.add(2)).toBe(true);
       expect(list.add(3)).toBe(true);
+    });
+
+    it("should report contextual validation failures with the original Zod cause", () => {
+      const strictList = new ArrayList<number>({
+        schema: z.number().int(),
+      });
+
+      let thrownError: unknown;
+
+      try {
+        strictList.add("text" as any);
+      } catch (error) {
+        thrownError = error;
+      }
+
+      expect(thrownError).toBeInstanceOf(TypeError);
+      expect((thrownError as Error).message).toContain(
+        "ArrayList.add() validation failed",
+      );
+      expect((thrownError as Error).message).toContain(
+        "Expected number for element at index 0, but got string \"text\"",
+      );
+      expect((thrownError as Error).message).toContain(
+        "size before operation: 0",
+      );
+      const cause = (thrownError as Error & { cause?: unknown }).cause;
+      expect(cause).toBeInstanceOf(Error);
+      expect((cause as Error).name).toBe("ZodError");
     });
   });
 

--- a/test/map/HashMap.test.ts
+++ b/test/map/HashMap.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import { z } from "zod";
 import { HashMap } from "../../src/map/HashMap";
 import { describeMap } from "../interfaces/Map";
 
@@ -89,6 +90,35 @@ describe("HashMap - Core Methods", () => {
       map.put("a", 100);
       expect(map.get("a")).toBe(100);
       expect(map.size()).toBe(1);
+    });
+
+    it("should report contextual validation failures with the original Zod cause", () => {
+      const strictMap = new HashMap<string, number>({
+        keySchema: z.string().min(1),
+        valueSchema: z.number().int(),
+      });
+
+      let thrownError: unknown;
+
+      try {
+        strictMap.put(123 as any, "text" as any);
+      } catch (error) {
+        thrownError = error;
+      }
+
+      expect(thrownError).toBeInstanceOf(TypeError);
+      expect((thrownError as Error).message).toContain(
+        "HashMap.put() validation failed",
+      );
+      expect((thrownError as Error).message).toContain(
+        "Expected string for key 123, but got number 123",
+      );
+      expect((thrownError as Error).message).toContain(
+        "size before operation: 0",
+      );
+      const cause = (thrownError as Error & { cause?: unknown }).cause;
+      expect(cause).toBeInstanceOf(Error);
+      expect((cause as Error).name).toBe("ZodError");
     });
   });
 

--- a/test/set/HashSet.test.ts
+++ b/test/set/HashSet.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import { z } from "zod";
 import { HashSet } from "../../src/set/HashSet";
 import { describeSet } from "../interfaces/Set";
 
@@ -70,6 +71,34 @@ describe("HashSet - Core Methods", () => {
       expect(set.add(2)).toBe(true);
       expect(set.add(3)).toBe(true);
       expect(set.size()).toBe(3);
+    });
+
+    it("should report contextual validation failures with the original Zod cause", () => {
+      const strictSet = new HashSet<number>({
+        schema: z.number().int(),
+      });
+
+      let thrownError: unknown;
+
+      try {
+        strictSet.add("text" as any);
+      } catch (error) {
+        thrownError = error;
+      }
+
+      expect(thrownError).toBeInstanceOf(TypeError);
+      expect((thrownError as Error).message).toContain(
+        "HashSet.add() validation failed",
+      );
+      expect((thrownError as Error).message).toContain(
+        "Expected number for set element, but got string \"text\"",
+      );
+      expect((thrownError as Error).message).toContain(
+        "size before operation: 0",
+      );
+      const cause = (thrownError as Error & { cause?: unknown }).cause;
+      expect(cause).toBeInstanceOf(Error);
+      expect((cause as Error).name).toBe("ZodError");
     });
 
     it("should maintain uniqueness when adding many duplicates", () => {


### PR DESCRIPTION
Contextual validation errors now include the collection type, operation, target description, and optional size info, with the original Zod error preserved in `cause`. The formatting and normalization live in validation.ts, and the abstract collection/map layers now pass operation-specific context from AbstractCollection.ts and AbstractMap.ts.

I also added regression coverage for the new behavior in ArrayList.test.ts, HashSet.test.ts, and HashMap.test.ts. Validation passed with `pnpm vitest run ArrayList.test.ts HashSet.test.ts test/map/HashMap.test.ts` and `pnpm type-check`. I couldn’t run `graphify update .` because `graphify` is not installed in this environment.


closes #36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Validation error messages now include contextual details about the operation, collection type, and collection state at the time of failure, improving debugging experience.

* **Tests**
  * Added test cases for validation error scenarios across collection implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Karelaking/ts-collections/pull/62?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->