### PR TITLE
🔒 Fix possible information leak through JSON.stringify in validation utilities

### DIFF
--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -72,7 +72,12 @@ function describeValue(value: unknown): string {
 	}
 
 	try {
-		return JSON.stringify(value);
+		return JSON.stringify(value, (key: string, val: unknown) => {
+			if (typeof key === "string" && /password|secret|token|credential|key/i.test(key)) {
+				return "[REDACTED]";
+			}
+			return val;
+		});
 	} catch {
 		return String(value);
 	}

--- a/test/utils/validation.test.ts
+++ b/test/utils/validation.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { describeValidationValue, formatValidationContextValue } from "../../src/utils/validation";
+
+describe("Validation utilities", () => {
+  it("should redact sensitive information in describeValidationValue", () => {
+    const sensitiveData = {
+      username: "jdoe",
+      password: "supersecretpassword",
+      apiToken: "1234567890abcdef",
+      accessToken: "abc1234",
+      secretKey: "shhh",
+      credentials: "user:pass",
+      normalField: "visible",
+    };
+
+    const described = describeValidationValue(sensitiveData);
+
+    // Should contain the normal field
+    expect(described).toContain('"normalField":"visible"');
+
+    // Should redact sensitive fields
+    expect(described).toContain('"password":"[REDACTED]"');
+    expect(described).toContain('"apiToken":"[REDACTED]"');
+    expect(described).toContain('"accessToken":"[REDACTED]"');
+    expect(described).toContain('"secretKey":"[REDACTED]"');
+    expect(described).toContain('"credentials":"[REDACTED]"');
+
+    // Should not contain sensitive values
+    expect(described).not.toContain("supersecretpassword");
+    expect(described).not.toContain("1234567890abcdef");
+    expect(described).not.toContain("abc1234");
+    expect(described).not.toContain("shhh");
+    expect(described).not.toContain("user:pass");
+  });
+
+  it("should redact sensitive information in formatValidationContextValue", () => {
+    const sensitiveData = {
+      key: "ssh-rsa AAAAB3NzaC1yc2...",
+    };
+
+    const formatted = formatValidationContextValue(sensitiveData);
+    expect(formatted).toContain('"key":"[REDACTED]"');
+    expect(formatted).not.toContain("ssh-rsa");
+  });
+
+  it("should format normal values correctly", () => {
+    expect(formatValidationContextValue("hello")).toBe('"hello"');
+    expect(formatValidationContextValue(123)).toBe("123");
+    expect(formatValidationContextValue(true)).toBe("true");
+    expect(formatValidationContextValue(null)).toBe("null");
+    expect(formatValidationContextValue(undefined)).toBe("undefined");
+    expect(formatValidationContextValue({ a: 1 })).toBe('{"a":1}');
+  });
+});

--- a/test/utils/validation.test.ts
+++ b/test/utils/validation.test.ts
@@ -2,53 +2,53 @@ import { describe, it, expect } from "vitest";
 import { describeValidationValue, formatValidationContextValue } from "../../src/utils/validation";
 
 describe("Validation utilities", () => {
-  it("should redact sensitive information in describeValidationValue", () => {
-    const sensitiveData = {
-      username: "jdoe",
-      password: "supersecretpassword",
-      apiToken: "1234567890abcdef",
-      accessToken: "abc1234",
-      secretKey: "shhh",
-      credentials: "user:pass",
-      normalField: "visible",
-    };
+	it("should redact sensitive information in describeValidationValue", () => {
+		const sensitiveData = {
+			username: "jdoe",
+			password: "supersecretpassword",
+			apiToken: "1234567890abcdef",
+			accessToken: "abc1234",
+			secretKey: "shhh",
+			credentials: "user:pass",
+			normalField: "visible",
+		};
 
-    const described = describeValidationValue(sensitiveData);
+		const described = describeValidationValue(sensitiveData);
 
-    // Should contain the normal field
-    expect(described).toContain('"normalField":"visible"');
+		// Should contain the normal field
+		expect(described).toContain('"normalField":"visible"');
 
-    // Should redact sensitive fields
-    expect(described).toContain('"password":"[REDACTED]"');
-    expect(described).toContain('"apiToken":"[REDACTED]"');
-    expect(described).toContain('"accessToken":"[REDACTED]"');
-    expect(described).toContain('"secretKey":"[REDACTED]"');
-    expect(described).toContain('"credentials":"[REDACTED]"');
+		// Should redact sensitive fields
+		expect(described).toContain('"password":"[REDACTED]"');
+		expect(described).toContain('"apiToken":"[REDACTED]"');
+		expect(described).toContain('"accessToken":"[REDACTED]"');
+		expect(described).toContain('"secretKey":"[REDACTED]"');
+		expect(described).toContain('"credentials":"[REDACTED]"');
 
-    // Should not contain sensitive values
-    expect(described).not.toContain("supersecretpassword");
-    expect(described).not.toContain("1234567890abcdef");
-    expect(described).not.toContain("abc1234");
-    expect(described).not.toContain("shhh");
-    expect(described).not.toContain("user:pass");
-  });
+		// Should not contain sensitive values
+		expect(described).not.toContain("supersecretpassword");
+		expect(described).not.toContain("1234567890abcdef");
+		expect(described).not.toContain("abc1234");
+		expect(described).not.toContain("shhh");
+		expect(described).not.toContain("user:pass");
+	});
 
-  it("should redact sensitive information in formatValidationContextValue", () => {
-    const sensitiveData = {
-      key: "ssh-rsa AAAAB3NzaC1yc2...",
-    };
+	it("should redact sensitive information in formatValidationContextValue", () => {
+		const sensitiveData = {
+			key: "ssh-rsa AAAAB3NzaC1yc2...",
+		};
 
-    const formatted = formatValidationContextValue(sensitiveData);
-    expect(formatted).toContain('"key":"[REDACTED]"');
-    expect(formatted).not.toContain("ssh-rsa");
-  });
+		const formatted = formatValidationContextValue(sensitiveData);
+		expect(formatted).toContain('"key":"[REDACTED]"');
+		expect(formatted).not.toContain("ssh-rsa");
+	});
 
-  it("should format normal values correctly", () => {
-    expect(formatValidationContextValue("hello")).toBe('"hello"');
-    expect(formatValidationContextValue(123)).toBe("123");
-    expect(formatValidationContextValue(true)).toBe("true");
-    expect(formatValidationContextValue(null)).toBe("null");
-    expect(formatValidationContextValue(undefined)).toBe("undefined");
-    expect(formatValidationContextValue({ a: 1 })).toBe('{"a":1}');
-  });
+	it("should format normal values correctly", () => {
+		expect(formatValidationContextValue("hello")).toBe('"hello"');
+		expect(formatValidationContextValue(123)).toBe("123");
+		expect(formatValidationContextValue(true)).toBe("true");
+		expect(formatValidationContextValue(null)).toBe("null");
+		expect(formatValidationContextValue(undefined)).toBe("undefined");
+		expect(formatValidationContextValue({ a: 1 })).toBe('{"a":1}');
+	});
 });


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The `describeValue` function in `src/utils/validation.ts` serializes values to strings (often for error messages/validation context). By default, it was serializing all object fields unredacted.

⚠️ **Risk:** The potential impact if left unfixed
Any validation error stringifying an object containing sensitive keys (like passwords, secret keys, or authentication tokens) would leak those values into logs, validation messages, or UI errors.

🛡️ **Solution:** How the fix addresses the vulnerability
A replacer function is now provided to `JSON.stringify` within `describeValue`. It matches common sensitive property names (case-insensitive checks for 'password', 'secret', 'token', 'credential', 'key') and replaces their values with `"[REDACTED]"`. Tests were also added to ensure this logic functions properly.

---
*PR created automatically by Jules for task [16206524346273847726](https://jules.google.com/task/16206524346273847726) started by @Karelaking*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Validation error messages now redact sensitive fields (passwords, secrets, tokens, credentials, keys), showing [REDACTED] instead of actual values.
  * Redaction applies across object inputs and multiple matching fields.

* **Tests**
  * New tests added to verify sensitive-data redaction and correct formatting of primitive and object validation values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Karelaking/ts-collections/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->