### PR TITLE
feat: add AsyncIterator interface and async iteration support (#40)

### DIFF
--- a/src/abstracts/AbstractCollection.ts
+++ b/src/abstracts/AbstractCollection.ts
@@ -1,6 +1,7 @@
 import type { ZodSchema } from "zod";
 import { ZodError } from "zod";
 import { TypeMismatchError, ValidationError } from "../errors";
+import type { AsyncIterator } from "../interfaces/AsyncIterator";
 import type { Collection, Iterator } from "../interfaces";
 import {
 	describeValidationValue,
@@ -241,6 +242,72 @@ export abstract class AbstractCollection<E> implements Collection<E> {
 	 * Must be implemented by subclasses.
 	 */
 	abstract clear(): void;
+
+	/**
+	 * Returns an async iterator over the elements in this collection.
+	 *
+	 * Each call to `hasNext()` and `next()` returns a Promise, making it
+	 * suitable for use in async pipelines and `for await...of` loops.
+	 *
+	 * The default implementation wraps the synchronous iterator, so
+	 * subclasses do not need to override this unless they have a genuinely
+	 * asynchronous data source.
+	 *
+	 * @example
+	 * ```typescript
+	 * const list = new ArrayList<number>();
+	 * list.add(1); list.add(2);
+	 *
+	 * // Explicit async iterator
+	 * const it = list.asyncIterator();
+	 * while (await it.hasNext()) {
+	 *   console.log(await it.next());
+	 * }
+	 *
+	 * // for-await-of loop (uses Symbol.asyncIterator)
+	 * for await (const item of list) {
+	 *   console.log(item);
+	 * }
+	 * ```
+	 */
+	asyncIterator(): AsyncIterator<E> {
+		const syncIt = this.iterator();
+		return {
+			hasNext: () => Promise.resolve(syncIt.hasNext()),
+			next: () => {
+				try {
+					return Promise.resolve(syncIt.next());
+				} catch (error) {
+					return Promise.reject(error);
+				}
+			},
+		};
+	}
+
+	/**
+	 * Implements the TC39 AsyncIterable protocol so that collections can be
+	 * used directly in `for await...of` loops.
+	 *
+	 * @example
+	 * ```typescript
+	 * for await (const item of list) {
+	 *   await processAsync(item);
+	 * }
+	 * ```
+	 */
+	[Symbol.asyncIterator](): globalThis.AsyncIterator<E> {
+		const asyncIt = this.asyncIterator();
+		return {
+			next: async () => {
+				const hasMore = await asyncIt.hasNext();
+				if (!hasMore) {
+					return { done: true as const, value: undefined as unknown as E };
+				}
+				const value = await asyncIt.next();
+				return { done: false as const, value };
+			},
+		};
+	}
 
 	/**
 	 * Returns true if this collection contains all of the elements

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,6 +125,7 @@ export {
 } from "./errors";
 // Core Interfaces
 export type {
+	AsyncIterator,
 	Collection,
 	Deque,
 	Iterator,

--- a/src/interfaces/AsyncIterator.ts
+++ b/src/interfaces/AsyncIterator.ts
@@ -1,0 +1,36 @@
+/**
+ * Async iterator interface for traversing collection elements asynchronously.
+ * Follows the TC39 AsyncIterable protocol and mirrors the synchronous Iterator
+ * interface, returning Promises instead of values directly.
+ *
+ * @template E The type of elements in the iteration
+ *
+ * @example
+ * const list = new ArrayList<string>();
+ * list.add("a");
+ * list.add("b");
+ *
+ * // Use the async iterator explicitly
+ * const asyncIt = list.asyncIterator();
+ * while (await asyncIt.hasNext()) {
+ *   console.log(await asyncIt.next());
+ * }
+ *
+ * // Or use for-await-of via Symbol.asyncIterator
+ * for await (const item of list) {
+ *   console.log(item);
+ * }
+ */
+export interface AsyncIterator<E> {
+	/**
+	 * Returns a Promise that resolves to true if the iteration has more elements.
+	 */
+	hasNext(): Promise<boolean>;
+
+	/**
+	 * Returns a Promise that resolves to the next element in the iteration.
+	 *
+	 * @throws Error if the iteration has no more elements
+	 */
+	next(): Promise<E>;
+}

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -4,6 +4,7 @@
 
 export type { Collection } from "./Collection";
 export type { Deque } from "./Deque";
+export type { AsyncIterator } from "./AsyncIterator";
 export type { Iterator } from "./Iterator";
 export type { List } from "./List";
 export type { Map } from "./Map";

--- a/test/interfaces/AsyncIterator.test.ts
+++ b/test/interfaces/AsyncIterator.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import type { AsyncIterator } from "../../src/interfaces/AsyncIterator";
+
+/**
+ * Shared test suite for AsyncIterator interface implementations.
+ * Import and call this from concrete-collection async iterator tests.
+ *
+ * @param createAsyncIterator Factory that returns an AsyncIterator over the given elements
+ */
+export function describeAsyncIterator(
+	createAsyncIterator: (elements: unknown[]) => AsyncIterator<unknown>,
+): void {
+	describe("AsyncIterator Interface", () => {
+		it("should resolve hasNext() to true when elements are available", async () => {
+			const it = createAsyncIterator([1, 2, 3]);
+			await expect(it.hasNext()).resolves.toBe(true);
+		});
+
+		it("should resolve hasNext() to false when iteration is exhausted", async () => {
+			const it = createAsyncIterator([1]) as AsyncIterator<number>;
+			await it.next();
+			await expect(it.hasNext()).resolves.toBe(false);
+		});
+
+		it("should resolve next() to elements in sequence", async () => {
+			const it = createAsyncIterator([10, 20, 30]) as AsyncIterator<number>;
+			await expect(it.next()).resolves.toBe(10);
+			await expect(it.next()).resolves.toBe(20);
+			await expect(it.next()).resolves.toBe(30);
+		});
+
+		it("should reject next() when the iterator is exhausted", async () => {
+			const it = createAsyncIterator([]) as AsyncIterator<number>;
+			await expect(it.next()).rejects.toThrow();
+		});
+
+		it("should iterate through all elements in order", async () => {
+			const elements = [1, 2, 3];
+			const it = createAsyncIterator(elements) as AsyncIterator<number>;
+			const result: number[] = [];
+			while (await it.hasNext()) {
+				result.push(await it.next());
+			}
+			expect(result).toEqual(elements);
+		});
+
+		it("should handle empty collection – hasNext() resolves to false immediately", async () => {
+			const it = createAsyncIterator([]);
+			await expect(it.hasNext()).resolves.toBe(false);
+		});
+
+		it("should handle single element", async () => {
+			const it = createAsyncIterator([42]) as AsyncIterator<number>;
+			await expect(it.hasNext()).resolves.toBe(true);
+			await expect(it.next()).resolves.toBe(42);
+			await expect(it.hasNext()).resolves.toBe(false);
+		});
+	});
+}

--- a/test/list/ArrayList.async-iterator.test.ts
+++ b/test/list/ArrayList.async-iterator.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { ArrayList } from "../../src/list/ArrayList";
+import { describeAsyncIterator } from "../interfaces/AsyncIterator.test";
+
+// Run the shared AsyncIterator contract tests against ArrayList
+describeAsyncIterator((elements) => {
+	const list = new ArrayList<unknown>({ strict: false });
+	for (const el of elements) {
+		list.add(el);
+	}
+	return list.asyncIterator();
+});
+
+describe("ArrayList - Async Iterator", () => {
+	let list: ArrayList<number>;
+
+	beforeEach(() => {
+		list = new ArrayList<number>();
+		list.addAll([1, 2, 3]);
+	});
+
+	it("asyncIterator() traverses elements in insertion order", async () => {
+		const it = list.asyncIterator();
+		const result: number[] = [];
+		while (await it.hasNext()) {
+			result.push(await it.next());
+		}
+		expect(result).toEqual([1, 2, 3]);
+	});
+
+	it("asyncIterator() rejects on next() when exhausted", async () => {
+		const it = list.asyncIterator();
+		await it.next();
+		await it.next();
+		await it.next();
+		await expect(it.next()).rejects.toThrow();
+	});
+
+	it("Symbol.asyncIterator enables for-await-of loops", async () => {
+		const collected: number[] = [];
+		for await (const item of list) {
+			collected.push(item);
+		}
+		expect(collected).toEqual([1, 2, 3]);
+	});
+
+	it("for-await-of works on an empty list", async () => {
+		const empty = new ArrayList<number>();
+		const collected: number[] = [];
+		for await (const item of empty) {
+			collected.push(item);
+		}
+		expect(collected).toEqual([]);
+	});
+
+	it("asyncIterator() on a single-element list resolves correctly", async () => {
+		const single = new ArrayList<number>();
+		single.add(99);
+		const it = single.asyncIterator();
+		await expect(it.hasNext()).resolves.toBe(true);
+		await expect(it.next()).resolves.toBe(99);
+		await expect(it.hasNext()).resolves.toBe(false);
+	});
+
+	it("multiple independent async iterators do not share state", async () => {
+		const it1 = list.asyncIterator();
+		const it2 = list.asyncIterator();
+		await expect(it1.next()).resolves.toBe(1);
+		// it2 is still at the start
+		await expect(it2.next()).resolves.toBe(1);
+	});
+});

--- a/test/list/LinkedList.async-iterator.test.ts
+++ b/test/list/LinkedList.async-iterator.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { LinkedList } from "../../src/list/LinkedList";
+
+describe("LinkedList - Async Iterator", () => {
+	let list: LinkedList<string>;
+
+	beforeEach(() => {
+		list = new LinkedList<string>();
+		list.addAll(["x", "y", "z"]);
+	});
+
+	it("asyncIterator() traverses elements in insertion order", async () => {
+		const it = list.asyncIterator();
+		const result: string[] = [];
+		while (await it.hasNext()) {
+			result.push(await it.next());
+		}
+		expect(result).toEqual(["x", "y", "z"]);
+	});
+
+	it("Symbol.asyncIterator enables for-await-of loops", async () => {
+		const collected: string[] = [];
+		for await (const item of list) {
+			collected.push(item);
+		}
+		expect(collected).toEqual(["x", "y", "z"]);
+	});
+
+	it("for-await-of works on an empty LinkedList", async () => {
+		const empty = new LinkedList<string>();
+		const collected: string[] = [];
+		for await (const item of empty) {
+			collected.push(item);
+		}
+		expect(collected).toEqual([]);
+	});
+
+	it("asyncIterator() rejects on next() when exhausted", async () => {
+		const it = list.asyncIterator();
+		await it.next();
+		await it.next();
+		await it.next();
+		await expect(it.next()).rejects.toThrow();
+	});
+});


### PR DESCRIPTION
## Description

Implements the TC39 AsyncIterable protocol for all collection types in ts-collections, resolving the lack of async iteration support reported in issue #40.

**Motivation:** Collections only supported blocking synchronous iteration via `Iterator<E>`. Modern TypeScript/JavaScript workflows — streaming data, database integration, async pipelines, and file I/O — require `for await...of` support and Promise-based traversal. This change adds that capability to **every collection in the framework** without requiring any per-class changes.

**Changes:**

- Add `AsyncIterator<E>` interface (`src/interfaces/AsyncIterator.ts`) with `hasNext(): Promise<boolean>` and `next(): Promise<E>`
- Add `asyncIterator()` and `[Symbol.asyncIterator]()` to `AbstractCollection` — all concrete collections (`ArrayList`, `LinkedList`, `HashSet`, `HashMap`, `LinkedQueue`, `LinkedStack`, etc.) inherit async iteration for free
- Export `AsyncIterator` from `src/interfaces/index.ts` and `src/index.ts`
- Add tests: `AsyncIterator` interface contract suite and `ArrayList`/`LinkedList`-specific tests including `for-await-of`, empty collection, and exhaustion rejection

This is a purely additive change; existing synchronous code is unaffected.

Fixes #40

---

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Other (please specify):

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code for security vulnerabilities
- [x] Any dependent changes have been merged and published in downstream modules

---

## Screenshots (if applicable)

N/A — no UI changes.

---

## How Has This Been Tested?

17 new tests were added across 3 test files. All pass locally.

**Test files added:**
- [x] `test/interfaces/AsyncIterator.test.ts` — shared contract test suite (7 tests covering `hasNext`, `next`, empty collection, exhaustion, single-element)
- [x] `test/list/ArrayList.async-iterator.test.ts` — ArrayList-specific tests (13 tests: insertion order, `for-await-of`, empty list, exhaustion rejection, multiple independent iterators)
- [x] `test/list/LinkedList.async-iterator.test.ts` — LinkedList-specific tests (4 tests: insertion order, `for-await-of`, empty list, exhaustion rejection)

**Reproduce locally:**
```bash
pnpm install
pnpm test
```

**Test Configuration:**
- OS: Windows 11
- Node.js version: v22.x
- pnpm: v10.18.1
- vitest: v4.1.9
- TypeScript: v5.9.3

---

## Related Documentation

- Issue: [#40 — No async iterator support despite synchronous Iterator implementation](https://github.com/Karelaking/ts-collections/issues/40)
- TC39 AsyncIterable Protocol: https://tc39.es/ecma262/#sec-asynciterable-interface
- MDN `for await...of`: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of

---

## Additional Notes

**Design decision — wrapping sync iterator:** The default `asyncIterator()` implementation in `AbstractCollection` wraps the existing synchronous `Iterator<E>`. This means all 10 concrete collection classes automatically gain async iteration without any per-class code. Subclasses with genuine async data sources (e.g., a database-backed collection) can override `asyncIterator()` to return a truly asynchronous implementation.

**Subtle implementation note:** `next()` uses a `try/catch` to convert synchronous throws (e.g., "No more elements") from the underlying sync iterator into rejected Promises — ensuring callers always receive a proper `Promise<E>` regardless of whether the iterator is exhausted, which is required for correct `for await...of` semantics.

**Pre-existing test failure:** `test/map/HashMap.test.ts > should report contextual validation failures with the original Zod cause` fails on `master` and is unrelated to this PR.

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Collections now support async iteration, enabling seamless use in `for await...of` loops for asynchronous traversal
  * New `AsyncIterator` interface provides promise-based APIs for checking element availability and retrieving elements asynchronously

* **Tests**
  * Added extensive test coverage for async iteration across all collection implementations, including edge cases and concurrent iterator scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->